### PR TITLE
Add teams under organizations

### DIFF
--- a/authapi/tests/test_api.py
+++ b/authapi/tests/test_api.py
@@ -829,7 +829,7 @@ class OrganizationTests(AuthAPITestCase):
 
         self.assertEqual(len(team.permissions.all()), 0)
 
-        print self.client.post(
+        self.client.post(
             reverse(
                 'seedorganization-teams-permissions-list',
                 args=[org.pk, team.pk]

--- a/authapi/tests/test_api.py
+++ b/authapi/tests/test_api.py
@@ -379,18 +379,10 @@ class TeamTests(AuthAPITestCase):
         self.assertEqual(len(response.data[0]['users']), 0)
 
     def test_create_team(self):
-        '''A POST request on the teams endpoint should create a team.'''
-        organization = SeedOrganization.objects.create()
-        data = {
-            'organization': organization.id,
-            'title': 'test team',
-        }
-        response = self.client.post(reverse('seedteam-list'), data=data)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
-        [team] = SeedTeam.objects.all()
-        self.assertEqual(team.organization, organization)
-        self.assertEqual(team.title, data['title'])
+        '''Creating teams on this endpoint should not be allowed.'''
+        response = self.client.post(reverse('seedteam-list'), data={})
+        self.assertEqual(
+            response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def test_delete_team(self):
         '''Deleting a team should archive the team instead of removing it.'''
@@ -403,16 +395,6 @@ class TeamTests(AuthAPITestCase):
 
         team.refresh_from_db()
         self.assertEqual(team.archived, True)
-
-    def test_create_team_no_required_fields(self):
-        '''An error should be returned if there is no organization field.'''
-        response = self.client.post(reverse('seedteam-list'), data={})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(
-            response.data, {
-                'organization': ['This field is required.'],
-                'title': ['This field is required.'],
-            })
 
     def test_update_team(self):
         '''A PUT request to a team's endpoint should update an existing

--- a/authapi/urls.py
+++ b/authapi/urls.py
@@ -6,7 +6,7 @@ from authapi import views
 router = routers.ExtendedSimpleRouter()
 
 org_router = router.register(r'organizations', views.OrganizationViewSet)
-team_router = router.register(r'teams', views.TeamViewSetNoCreate)
+team_router = router.register(r'teams', views.TeamViewSet)
 router.register(r'users', views.UserViewSet)
 
 org_router.register(
@@ -14,7 +14,7 @@ org_router.register(
     base_name='seedorganization-users',
     parents_query_lookups=['organization'])
 orgteam_router = org_router.register(
-    r'teams', views.TeamViewSet,
+    r'teams', views.OrganizationTeamViewSet,
     base_name='seedorganization-teams',
     parents_query_lookups=['organization'])
 

--- a/authapi/urls.py
+++ b/authapi/urls.py
@@ -6,7 +6,7 @@ from authapi import views
 router = routers.ExtendedSimpleRouter()
 
 org_router = router.register(r'organizations', views.OrganizationViewSet)
-team_router = router.register(r'teams', views.TeamViewSet)
+team_router = router.register(r'teams', views.TeamViewSetNoCreate)
 router.register(r'users', views.UserViewSet)
 
 org_router.register(

--- a/authapi/urls.py
+++ b/authapi/urls.py
@@ -13,15 +13,19 @@ org_router.register(
     r'users', views.OrganizationUsersViewSet,
     base_name='seedorganization-users',
     parents_query_lookups=['organization'])
+orgteam_router = org_router.register(
+    r'teams', views.TeamViewSet,
+    base_name='seedorganization-teams',
+    parents_query_lookups=['organization'])
 
 team_router.register(
     r'permissions', views.TeamPermissionViewSet,
     base_name='seedteam-permissions',
-    parents_query_lookups=['team'])
+    parents_query_lookups=['seedteam'])
 team_router.register(
     r'users', views.TeamUsersViewSet,
     base_name='seedteam-users',
-    parents_query_lookups=['team'])
+    parents_query_lookups=['seedteam'])
 
 urlpatterns = [
     url(r'^', include(router.urls)),

--- a/authapi/urls.py
+++ b/authapi/urls.py
@@ -1,34 +1,28 @@
 from django.conf.urls import include, url
-from rest_framework_nested import routers
+from rest_framework_extensions import routers
 
 from authapi import views
 
-router = routers.DefaultRouter()
-router.register(r'organizations', views.OrganizationViewSet)
-router.register(r'teams', views.TeamViewSet)
+router = routers.ExtendedSimpleRouter()
+
+org_router = router.register(r'organizations', views.OrganizationViewSet)
+team_router = router.register(r'teams', views.TeamViewSet)
 router.register(r'users', views.UserViewSet)
 
-orgusers_router = routers.NestedSimpleRouter(
-    router, r'organizations', lookup='organization')
-orgusers_router.register(
+org_router.register(
     r'users', views.OrganizationUsersViewSet,
-    base_name='seedorganization-users')
+    base_name='seedorganization-users',
+    parents_query_lookups=['organization'])
 
-permissions_router = routers.NestedSimpleRouter(
-    router, r'teams', lookup='team')
-permissions_router.register(
+team_router.register(
     r'permissions', views.TeamPermissionViewSet,
-    base_name='seedteam-permissions')
-
-teamusers_router = routers.NestedSimpleRouter(
-    router, r'teams', lookup='team')
-teamusers_router.register(
+    base_name='seedteam-permissions',
+    parents_query_lookups=['team'])
+team_router.register(
     r'users', views.TeamUsersViewSet,
-    base_name='seedteam-users')
+    base_name='seedteam-users',
+    parents_query_lookups=['team'])
 
 urlpatterns = [
     url(r'^', include(router.urls)),
-    url(r'^', include(orgusers_router.urls)),
-    url(r'^', include(permissions_router.urls)),
-    url(r'^', include(teamusers_router.urls)),
 ]

--- a/authapi/urls.py
+++ b/authapi/urls.py
@@ -18,6 +18,11 @@ orgteam_router = org_router.register(
     base_name='seedorganization-teams',
     parents_query_lookups=['organization'])
 
+orgteam_router.register(
+    r'permissions', views.TeamPermissionViewSet,
+    base_name='seedorganization-teams-permissions',
+    parents_query_lookups=['seedteam__organization', 'seedteam'])
+
 team_router.register(
     r'permissions', views.TeamPermissionViewSet,
     base_name='seedteam-permissions',

--- a/authapi/urls.py
+++ b/authapi/urls.py
@@ -22,6 +22,11 @@ orgteam_router.register(
     r'permissions', views.TeamPermissionViewSet,
     base_name='seedorganization-teams-permissions',
     parents_query_lookups=['seedteam__organization', 'seedteam'])
+orgteam_router.register(
+    r'users', views.TeamUsersViewSet,
+    base_name='seedorganization-teams-users',
+    parents_query_lookups=['seedteam__organization', 'seedteam'])
+
 
 team_router.register(
     r'permissions', views.TeamPermissionViewSet,

--- a/authapi/views.py
+++ b/authapi/views.py
@@ -130,22 +130,24 @@ class TeamPermissionViewSet(
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
-class TeamUsersViewSet(NestedViewSetMixin, viewsets.ViewSet):
+class TeamUsersViewSet(NestedViewSetMixin, GenericViewSet):
     '''Nested viewset that allows users to add or remove users from teams.'''
+    queryset = User.objects.all()
+    serializer_class = ExistingUserSerializer
 
-    def create(self, request, parent_lookup_team=None):
+    def create(self, request, parent_lookup_seedteam=None, **kwargs):
         '''Add a user to a team.'''
-        serializer = ExistingUserSerializer(data=request.data)
+        serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         user = get_object_or_404(User, pk=serializer.data['user_id'])
-        team = get_object_or_404(SeedTeam, pk=parent_lookup_team)
+        team = get_object_or_404(SeedTeam, pk=parent_lookup_seedteam)
         team.users.add(user)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    def destroy(self, request, pk=None, parent_lookup_team=None):
+    def destroy(self, request, pk=None, parent_lookup_seedteam=None, **kwargs):
         '''Remove a user from an organization.'''
-        user = get_object_or_404(User, pk=pk)
-        team = get_object_or_404(SeedTeam, pk=parent_lookup_team)
+        user = self.get_object()
+        team = get_object_or_404(SeedTeam, pk=parent_lookup_seedteam)
         team.users.remove(user)
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/authapi/views.py
+++ b/authapi/views.py
@@ -116,7 +116,10 @@ class TeamViewSet(viewsets.ModelViewSet):
 
 class TeamPermissionViewSet(NestedViewSetMixin, viewsets.ViewSet):
     '''Nested viewset to add and remove permissions from teams.'''
-    def create(self, request, parent_lookup_team=None):
+    queryset = SeedPermission.objects.all()
+    serializer_class = PermissionSerializer
+
+    def create(self, request, parent_lookup_seedteam=None, **kwargs):
         '''Add a permission to a team.'''
         serializer = PermissionSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/authapi/views.py
+++ b/authapi/views.py
@@ -76,7 +76,7 @@ class OrganizationUsersViewSet(NestedViewSetMixin, viewsets.ViewSet):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class TeamViewSetNoCreate(
+class BaseTeamViewSet(
         NestedViewSetMixin, RetrieveModelMixin, UpdateModelMixin,
         DestroyModelMixin, ListModelMixin, GenericViewSet):
     queryset = SeedTeam.objects.all()
@@ -92,7 +92,7 @@ class TeamViewSetNoCreate(
         We also have the query params permission_contains and object_id, which
         allow users to filter the teams based on the permissions they
         contain.'''
-        queryset = super(TeamViewSetNoCreate, self).get_queryset()
+        queryset = super(BaseTeamViewSet, self).get_queryset()
         if self.action == 'list':
             archived = get_true_false_both(
                 self.request.query_params, 'archived', 'false')
@@ -118,11 +118,15 @@ class TeamViewSetNoCreate(
         instance.save()
 
 
-class TeamViewSet(TeamViewSetNoCreate, CreateModelMixin):
+class TeamViewSet(BaseTeamViewSet):
+    pass
+
+
+class OrganizationTeamViewSet(BaseTeamViewSet, CreateModelMixin):
     def create(self, request, parent_lookup_organization=None):
         if parent_lookup_organization is not None:
             request.data['organization'] = parent_lookup_organization
-        return super(TeamViewSet, self).create(request)
+        return super(OrganizationTeamViewSet, self).create(request)
 
 
 class TeamPermissionViewSet(

--- a/docs/http_api.rst
+++ b/docs/http_api.rst
@@ -429,9 +429,84 @@ to belong to exactly one organization, but an organization can have many teams.
 
         HTTP/1.1 204 No Content
 
+.. http:post:: /organizations/(int:organization_id)/teams/
+
+    Create a new team.
+
+    :<json str title: The title of the team.
+
+    :>json int id: The ID of the created team.
+    :>json str url: The URL of the created team.
+    :>json str title: the title of the team.
+    :>json list users: The list of users that belong to this team.
+    :>json int organization: The id of the organization that the team belongs to.
+    :>json list permissions: The permission list for the team.
+    :status 201: Successfully created team.
+    :status 422: Missing required information to create team.
+
+    **Example request**:
+
+    .. sourcecode:: http
+
+        POST /organizations/7/teams/ HTTP/1.1
+        Content-Type: application/json
+
+        {
+            "title": "Lord Commanders",
+        }
+
+    **Example response**:
+
+    .. sourcecode:: http
+
+        HTTP/1.1 201 Created
+        Content-Type: application/json
+
+        {
+            "id": 2,
+            "title": "Lord Commanders",
+            "users": [],
+            "permissions": [],
+            "url": "https://example.org/teams/2",
+            "organization": 7
+        }
+
+.. http:get:: /organizations/(int:organization_id)/teams/
+
+    See `Get list of teams`_. Limited to teams that belong to the organization.
+
+.. http:get:: /organizations/(int:organization_id)/teams/(int:team:id)/
+
+    See `Get team details`_. Limited to teams that belong to the organization.
+
+.. http:put:: /organizations/(int:organization_id)/teams/(int:team:id)/
+
+    See `Update team details`_. Limited to teams that belong to the organization.
+
+.. http:delete:: /organizations/(int:organization_id)/teams/(int:team:id)/
+
+    See `Delete team`_. Limited to teams that belong to the organization.
+
+.. http:post:: /organizations/(int:organization_id)/teams/(int:team:id)/permissions/
+
+    See `Add permission to team`_. Limited to teams that belong to the organization.
+
+.. http:delete:: /organizations/(int:organization_id)/teams/(int:team:id)/permissions/(int:permission_id)/
+
+    See `Remove permission from team`_. Limited to teams that belong to the organization.
+
+.. http:post:: /organizations/(int:organization_id)/teams/(int:team:id)/users/
+
+    See `Add user to team`_. Limited to teams that belong to the organization.
+
+.. http:delete:: /organizations/(int:organization_id)/teams/(int:team:id)/user/(int:user_id)/
+
+    See `Remove user from team`_. Limited to teams that belong to the organization.
+
 Teams
 ^^^^^
 
+.. _Get list of teams:
 .. http:get:: /teams/
 
     Get a list of all the teams you have read access to.
@@ -521,50 +596,7 @@ Teams
         ]
 
 
-.. http:post:: /teams/
-
-    Create a new team.
-
-    :<json str title: The title of the team.
-    :<json int organization: The id of the organization that the team belongs to.
-
-    :>json int id: The ID of the created team.
-    :>json str url: The URL of the created team.
-    :>json str title: the title of the team.
-    :>json list users: The list of users that belong to this team.
-    :>json int organization: The id of the organization that the team belongs to.
-    :>json list permissions: The permission list for the team.
-    :status 201: Successfully created team.
-    :status 422: Missing required information to create team.
-
-    **Example request**:
-
-    .. sourcecode:: http
-
-        POST /teams/ HTTP/1.1
-        Content-Type: application/json
-
-        {
-            "title": "Lord Commanders",
-            "organization": 7
-        }
-
-    **Example response**:
-
-    .. sourcecode:: http
-
-        HTTP/1.1 201 Created
-        Content-Type: application/json
-
-        {
-            "id": 2,
-            "title": "Lord Commanders",
-            "users": [],
-            "permissions": [],
-            "url": "https://example.org/teams/2",
-            "organization": 7
-        }
-
+.. _Get team details:
 .. http:get:: /teams/(int:team_id)
 
     Get the details of a team.
@@ -599,6 +631,7 @@ Teams
             "organization": 7
         }
 
+.. _Update team details:
 .. http:put:: /teams/(int:team_id)
 
     Update the details of a team.
@@ -640,6 +673,7 @@ Teams
             "organization": 7
         }
 
+.. _Delete team:
 .. http:delete:: /teams/(int:team_id)
 
     Remove a team.
@@ -658,6 +692,7 @@ Teams
 
         HTTP/1.1 204 No Content
 
+.. _Add permission to team:
 .. http:post:: /teams/(int:team_id)/permissions/
 
     Add a permission to a team.
@@ -719,6 +754,7 @@ Teams
             "organization": 7
         }
 
+.. _Remove permission from team:
 .. http:delete:: /teams/(int:team_id)/permissions/(int:permission_id)
 
     Remove a permission from a team.
@@ -753,6 +789,7 @@ Teams
             "organization": 7
         }
 
+.. _Add user to team:
 .. http:post:: /teams/(int:team_id)/users/
 
     Add an existing user to an existing team.
@@ -800,6 +837,7 @@ Teams
             "organization": 7
         }
 
+.. _Remove user from team:
 .. http:delete:: /teams/(int:team_id)/users/1
 
     Remove a user from a team.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         'dj_database_url==0.4.1',
         'psycopg2cffi==2.7.4',
         'djangorestframework==3.3.3',
-        'drf-extensions-0.2.8',
+        'drf-extensions==0.2.8',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         'dj_database_url==0.4.1',
         'psycopg2cffi==2.7.4',
         'djangorestframework==3.3.3',
-        'drf-nested-routers==0.11.1',
+        'drf-extensions-0.2.8',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Since teams have a one to many relationship with organizations, it would make more sense to have them situated under `/organizations/<orgid>/teams/..`. This way we no longer need to specify an `organization` id field when creating the team. We do still want to be able to query all teams though.

So the implementation plan is to have the `/organizations/<orgid>/teams/` endpoints for CRUDL operations (where you can only perform actions on teams of that organization), and to also have a `/teams/` endpoint where you can do the same, except for create, but you can perform actions on all teams, instead of just the teams of a single organization.