### PR TITLE
Don't require password field for PUT /users/<id>

### DIFF
--- a/authapi/serializers.py
+++ b/authapi/serializers.py
@@ -92,11 +92,14 @@ class NewUserSerializer(BaseUserSerializer):
 
 
 class UserSerializer(BaseUserSerializer):
+    password = serializers.CharField(
+        style={'input_type': 'password'}, write_only=True, required=False)
+
     class Meta:
         model = User
         fields = (
             'id', 'url', 'first_name', 'last_name', 'email', 'admin', 'teams',
-            'organizations', 'active')
+            'organizations', 'active', 'password')
 
     def update(self, instance, validated_data):
         '''We want to set all the required fields if admin is set, and we want
@@ -111,6 +114,8 @@ class UserSerializer(BaseUserSerializer):
         if admin is not None:
             instance.is_staff = admin
             instance.is_superuser = admin
+        if password is not None:
+            instance.set_password(password)
 
         instance.save()
         return instance

--- a/authapi/serializers.py
+++ b/authapi/serializers.py
@@ -66,20 +66,9 @@ class BaseUserSerializer(serializers.ModelSerializer):
     admin = serializers.BooleanField(source='is_superuser', required=False)
     active = serializers.BooleanField(default=True, source='is_active')
 
-
-class NewUserSerializer(BaseUserSerializer):
-    password = serializers.CharField(
-        style={'input_type': 'password'}, write_only=True)
-
-    class Meta:
-        model = User
-        fields = (
-            'id', 'url', 'first_name', 'last_name', 'email', 'admin', 'teams',
-            'organizations', 'password', 'active')
-
     def create(self, validated_data):
-        '''We want to set the username to be the same as the email, and use the
-        correct create function to make use of password hashing.'''
+        '''We want to set the username to be the same as the email, and use
+        the correct create function to make use of password hashing.'''
         validated_data['username'] = validated_data['email']
         admin = validated_data.pop('is_superuser', None)
 
@@ -89,17 +78,6 @@ class NewUserSerializer(BaseUserSerializer):
             user = User.objects.create_user(**validated_data)
 
         return user
-
-
-class UserSerializer(BaseUserSerializer):
-    password = serializers.CharField(
-        style={'input_type': 'password'}, write_only=True, required=False)
-
-    class Meta:
-        model = User
-        fields = (
-            'id', 'url', 'first_name', 'last_name', 'email', 'admin', 'teams',
-            'organizations', 'active', 'password')
 
     def update(self, instance, validated_data):
         '''We want to set all the required fields if admin is set, and we want
@@ -119,3 +97,25 @@ class UserSerializer(BaseUserSerializer):
 
         instance.save()
         return instance
+
+
+class NewUserSerializer(BaseUserSerializer):
+    password = serializers.CharField(
+        style={'input_type': 'password'}, write_only=True)
+
+    class Meta:
+        model = User
+        fields = (
+            'id', 'url', 'first_name', 'last_name', 'email', 'admin', 'teams',
+            'organizations', 'password', 'active')
+
+
+class UserSerializer(BaseUserSerializer):
+    password = serializers.CharField(
+        style={'input_type': 'password'}, write_only=True, required=False)
+
+    class Meta:
+        model = User
+        fields = (
+            'id', 'url', 'first_name', 'last_name', 'email', 'admin', 'teams',
+            'organizations', 'active', 'password')

--- a/authapi/serializers.py
+++ b/authapi/serializers.py
@@ -57,7 +57,7 @@ class TeamSerializer(serializers.ModelSerializer):
             'archived')
 
 
-class BaseUserSerializer(serializers.ModelSerializer):
+class UserSerializer(serializers.ModelSerializer):
     teams = TeamSummarySerializer(
         many=True, source='seedteam_set', read_only=True)
     organizations = OrganizationSummarySerializer(
@@ -65,6 +65,14 @@ class BaseUserSerializer(serializers.ModelSerializer):
     email = serializers.EmailField()
     admin = serializers.BooleanField(source='is_superuser', required=False)
     active = serializers.BooleanField(default=True, source='is_active')
+    password = serializers.CharField(
+        style={'input_type': 'password'}, write_only=True, required=False)
+
+    class Meta:
+        model = User
+        fields = (
+            'id', 'url', 'first_name', 'last_name', 'email', 'admin', 'teams',
+            'organizations', 'password', 'active')
 
     def create(self, validated_data):
         '''We want to set the username to be the same as the email, and use
@@ -99,23 +107,6 @@ class BaseUserSerializer(serializers.ModelSerializer):
         return instance
 
 
-class NewUserSerializer(BaseUserSerializer):
+class NewUserSerializer(UserSerializer):
     password = serializers.CharField(
-        style={'input_type': 'password'}, write_only=True)
-
-    class Meta:
-        model = User
-        fields = (
-            'id', 'url', 'first_name', 'last_name', 'email', 'admin', 'teams',
-            'organizations', 'password', 'active')
-
-
-class UserSerializer(BaseUserSerializer):
-    password = serializers.CharField(
-        style={'input_type': 'password'}, write_only=True, required=False)
-
-    class Meta:
-        model = User
-        fields = (
-            'id', 'url', 'first_name', 'last_name', 'email', 'admin', 'teams',
-            'organizations', 'active', 'password')
+        style={'input_type': 'password'}, write_only=True, required=True)

--- a/authapi/tests/test_api.py
+++ b/authapi/tests/test_api.py
@@ -157,6 +157,21 @@ class UserTests(AuthAPITestCase):
         self.assertEqual(user.is_superuser, data['admin'])
         self.assertTrue(check_password(data['password'], user.password))
 
+    def test_create_user_no_password(self):
+        '''A POST request to the user endpoint without a password field should
+        yield a validation error response'''
+        data = {
+            'email': 'user1@example.org',
+            'first_name': 'user1',
+            'last_name': 'example',
+            'admin': False,
+        }
+        response = self.client.post(reverse('user-list'), data=data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, {
+            'password': ['This field is required.'],
+        })
+
     def test_update_user(self):
         '''A PUT request to the user's endpoint should update that specific
         user's details.'''

--- a/authapi/tests/test_api.py
+++ b/authapi/tests/test_api.py
@@ -192,6 +192,26 @@ class UserTests(AuthAPITestCase):
         self.assertEqual(user.last_name, data['last_name'])
         self.assertEqual(user.is_superuser, data['admin'])
 
+    def test_update_user_password(self):
+        '''A PUT request to the user's endpoint with a password field should
+        reset the user's password.'''
+        user = User.objects.create_user('user@example.org')
+
+        data = {
+            'email': 'new@email.org',
+            'first_name': 'new',
+            'last_name': 'user',
+            'admin': True,
+            'password': 'testpassword',
+        }
+
+        response = self.client.put(
+            reverse('user-detail', args=[user.id]), data=data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        user.refresh_from_db()
+        self.assertTrue(check_password(data['password'], user.password))
+
     def test_get_user(self):
         '''A GET request to a specific user's endpoint should return the
         details for that user.'''

--- a/authapi/views.py
+++ b/authapi/views.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 
 from authapi.models import SeedOrganization, SeedTeam, SeedPermission
 from authapi.serializers import (
-    OrganizationSerializer, TeamSerializer, UserSerializer,
+    OrganizationSerializer, TeamSerializer, UserSerializer, NewUserSerializer,
     ExistingUserSerializer, PermissionSerializer)
 
 
@@ -153,7 +153,12 @@ class TeamUsersViewSet(viewsets.ViewSet):
 
 class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
-    serializer_class = UserSerializer
+
+    def get_serializer_class(self):
+        if self.action == 'create':
+            return NewUserSerializer
+        else:
+            return UserSerializer
 
     def get_queryset(self):
         '''We want to still be able to modify archived users, but they


### PR DESCRIPTION
At the moment, we get the following response:

```http
HTTP/1.0 400 Bad Request
{"password":["This field is required."]}
```