### PR TITLE
Mention org and team archiving for DELETE in docs

### DIFF
--- a/docs/http_api.rst
+++ b/docs/http_api.rst
@@ -376,10 +376,10 @@ to belong to exactly one organization, but an organization can have many teams.
 
     Archive an organization. The organization will by default no longer be
     shown when :ref:`listing organizations <organizations-list>`, the
-    organization's teams will no longer be shown when :ref:`listing teams
-    <teams-list>`, and any permissions associated with the organization's teams
-    will no longer take effect when checking whether a user has permission to
-    perform an action.
+    organization's teams will by default no longer be shown when :ref:`listing
+    teams <teams-list>`, and any permissions associated with the organization's
+    teams will no longer take effect when checking whether a user has
+    permission to perform an action.
 
     Archiving can be reversed by setting ``archived`` to ``true`` when
     :ref:`updating <organizations-update>` an organization.
@@ -706,10 +706,10 @@ Teams
 .. _Delete team:
 .. http:delete:: /teams/(int:team_id)
 
-    Archive a team. The team will no longer be shown when :ref:`listing teams
-    <teams-list>`, and any permissions associated with the team will no longer
-    take effect when checking whether a user has permission to perform an
-    action.
+    Archive a team. The team will by default no longer be shown when
+    :ref:`listing teams <teams-list>`, and any permissions associated with the
+    team will no longer take effect when checking whether a user has permission
+    to perform an action.
 
     Archiving can be reversed by setting ``archived`` to ``true`` when
     :ref:`updating <teams-update>` a team.

--- a/docs/http_api.rst
+++ b/docs/http_api.rst
@@ -294,6 +294,7 @@ to belong to exactly one organization, but an organization can have many teams.
 
         {"title":"Nights Watch","id":4,"teams":[],"url":"https://example.org/organizations/4","users":[]}
 
+.. _organizations-list:
 .. http:get:: /organizations/
 
     Get a list of existing organizations
@@ -341,6 +342,7 @@ to belong to exactly one organization, but an organization can have many teams.
 
        {"title":"Night's Watch","id":4,"teams":[],"url":"https://example.org/organizations/4","users":[]}
 
+.. _organizations-update:
 .. http:put:: /organizations/(int:organization_id)
 
     Update an existing organization.
@@ -372,9 +374,17 @@ to belong to exactly one organization, but an organization can have many teams.
 
 .. http:delete:: /organizations/(int:organization_id)
 
-    Remove an existing organization.
+    Archive an organization. The organization will by default no longer be
+    shown when :ref:`listing organizations <organizations-list>`, the
+    organization's teams will no longer be shown when :ref:`listing teams
+    <teams-list>`, and any permissions associated with the organization's teams
+    will no longer take effect when checking whether a user has permission to
+    perform an action.
 
-    :status 204: Resource successfully deleted
+    Archiving can be reversed by setting ``archived`` to ``true`` when
+    :ref:`updating <organizations-update>` an organization.
+
+    :status 204: Organization successfully archived
 
    **Example request**:
 
@@ -510,6 +520,7 @@ Teams
 ^^^^^
 
 .. _Get list of teams:
+.. _teams-list:
 .. http:get:: /teams/
 
     Get a list of all the teams you have read access to.
@@ -647,6 +658,7 @@ Teams
         }
 
 .. _Update team details:
+.. _teams-update:
 .. http:put:: /teams/(int:team_id)
 
     Update the details of a team.
@@ -694,9 +706,15 @@ Teams
 .. _Delete team:
 .. http:delete:: /teams/(int:team_id)
 
-    Remove a team.
+    Archive a team. The team will no longer be shown when :ref:`listing teams
+    <teams-list>`, and any permissions associated with the team will no longer
+    take effect when checking whether a user has permission to perform an
+    action.
 
-    :status 204: Team successfully deleted.
+    Archiving can be reversed by setting ``archived`` to ``true`` when
+    :ref:`updating <teams-update>` a team.
+
+    :status 204: Team successfully archived.
 
     **Example request**:
 

--- a/docs/http_api.rst
+++ b/docs/http_api.rst
@@ -498,7 +498,7 @@ to belong to exactly one organization, but an organization can have many teams.
 
 .. http:delete:: /organizations/(int:organization_id)/teams/(int:team:id)/
 
-    See `Delete team`_. Limited to teams that belong to the organization.
+    See `Archive team`_. Limited to teams that belong to the organization.
 
 .. http:post:: /organizations/(int:organization_id)/teams/(int:team:id)/permissions/
 
@@ -703,7 +703,7 @@ Teams
             }
         }
 
-.. _Delete team:
+.. _Archive team:
 .. http:delete:: /teams/(int:team_id)
 
     Archive a team. The team will by default no longer be shown when


### PR DESCRIPTION
At the moment, `DELETE` for organization and team endpoints in the docs suggests we delete organizations and teams, when we actually archive them.