### PR TITLE
Add authorization to organizations endpoint

### DIFF
--- a/authapi/permissions.py
+++ b/authapi/permissions.py
@@ -1,0 +1,77 @@
+from restfw_composed_permissions.base import (
+    BaseComposedPermision, BasePermissionComponent, And, Or)
+from restfw_composed_permissions.generic.components import (
+    AllowOnlyAuthenticated, AllowOnlySafeHttpMethod)
+
+from authapi.utils import get_user_permissions, find_permission
+
+
+class AllowPermission(BasePermissionComponent):
+    '''
+    This component checks whether a user has a specific permission type.
+    '''
+    def __init__(self, permission_type, object_id=None):
+        self.permission_type = permission_type
+
+    def has_permission(self, permission, request, view):
+        user = request.user
+        permissions = get_user_permissions(user)
+        permissions = find_permission(permissions, self.permission_type)
+        if permissions.count() >= 1:
+            return True
+        return False
+
+    def has_object_permission(self, permission, request, view, obj):
+        return self.has_permission(permission, request, view)
+
+
+class AllowObjectPermission(AllowPermission):
+    '''This component checks whether a user has a specific permission type,
+    and that the object id matches the permission object id.'''
+    def has_object_permission(self, permission, request, view, obj):
+        user = request.user
+        permissions = get_user_permissions(user)
+        permissions = find_permission(
+            permissions, self.permission_type, str(obj.pk))
+        if permissions.count() >= 1:
+            return True
+        return False
+
+
+class AllowAdmin(BasePermissionComponent):
+    '''
+    This component will always allow admin users, and deny all other users.
+    '''
+    def has_object_permission(self, permission, request, view, obj):
+        return request.user.is_superuser
+
+    def has_permission(self, permission, request, view):
+        return request.user.is_superuser
+
+
+class OrganizationPermission(BaseComposedPermision):
+    '''Permissions for the OrganizationViewSet.'''
+    def global_permission_set(self):
+        '''All users can read, admins and org:admins can create.'''
+        return And(
+            AllowOnlyAuthenticated,
+            Or(
+                AllowOnlySafeHttpMethod,
+                AllowAdmin,
+                lambda _: AllowPermission('org:admin')
+            )
+        )
+
+    def object_permission_set(self):
+        '''
+        All users can read, admins, org:admins, and users with org:write
+        permission for the specific organization can update.'''
+        return And(
+            AllowOnlyAuthenticated,
+            Or(
+                AllowOnlySafeHttpMethod,
+                AllowAdmin,
+                lambda _: AllowPermission('org:admin'),
+                lambda _: AllowObjectPermission('org:write')
+            )
+        )

--- a/authapi/permissions.py
+++ b/authapi/permissions.py
@@ -48,6 +48,15 @@ class AllowUpdate(BasePermissionComponent):
         return request.method in ('PUT', 'PATCH')
 
 
+class AllowDelete(BasePermissionComponent):
+    '''Only allows DELETE requests.'''
+    def has_permission(self, permission, request, view):
+        return request.method == 'DELETE'
+
+
+AllowModify = Or(AllowUpdate, AllowDelete)
+
+
 class AllowAdmin(BasePermissionComponent):
     '''
     This component will always allow admin users, and deny all other users.
@@ -74,6 +83,6 @@ class OrganizationPermission(BaseComposedPermision):
         return Or(
             AllowOnlySafeHttpMethod,
             AllowAdmin,
-            And(Or(AllowCreate, AllowUpdate), AllowPermission('org:admin')),
-            And(AllowUpdate, AllowObjectPermission('org:write'))
+            And(Or(AllowCreate, AllowModify), AllowPermission('org:admin')),
+            And(AllowModify, AllowObjectPermission('org:write'))
         )

--- a/authapi/permissions.py
+++ b/authapi/permissions.py
@@ -10,7 +10,7 @@ class AllowPermission(BasePermissionComponent):
     '''
     This component checks whether a user has a specific permission type.
     '''
-    def __init__(self, permission_type, object_id=None):
+    def __init__(self, permission_type):
         self.permission_type = permission_type
 
     def has_permission(self, permission, request, view):

--- a/authapi/permissions.py
+++ b/authapi/permissions.py
@@ -34,7 +34,6 @@ class AllowObjectPermission(AllowPermission):
             permissions, self.permission_type, str(obj.pk))
         if permissions.count() >= 1:
             return True
-        return False
 
 
 class AllowCreate(BasePermissionComponent):
@@ -53,9 +52,6 @@ class AllowAdmin(BasePermissionComponent):
     '''
     This component will always allow admin users, and deny all other users.
     '''
-    def has_object_permission(self, permission, request, view, obj):
-        return request.user.is_superuser
-
     def has_permission(self, permission, request, view):
         return request.user.is_superuser
 

--- a/authapi/serializers.py
+++ b/authapi/serializers.py
@@ -2,6 +2,7 @@ from django.contrib.auth.models import User
 from rest_framework import serializers
 
 from authapi.models import SeedOrganization, SeedTeam, SeedPermission
+from authapi.utils import get_user_permissions
 from authapi.validators import CreateOnly
 
 
@@ -135,14 +136,7 @@ class PermissionsUserSerializer(BaseUserSerializer):
     permissions = serializers.SerializerMethodField()
 
     def get_permissions(self, user):
-        permissions = SeedPermission.objects.all()
-        # User must be on a team that grants the permission
-        permissions = permissions.filter(seedteam__users=user)
-        # The team must be active
-        permissions = permissions.filter(seedteam__archived=False)
-        # The organization of that team must be active
-        permissions = permissions.filter(
-            seedteam__organization__archived=False)
+        permissions = get_user_permissions(user)
         serializer = PermissionSerializer(instance=permissions, many=True)
         return serializer.data
 

--- a/authapi/tests/base.py
+++ b/authapi/tests/base.py
@@ -1,4 +1,6 @@
+from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
+from rest_framework.authtoken.models import Token
 from rest_framework.request import Request
 from rest_framework.reverse import reverse as drt_reverse
 from rest_framework.test import APITestCase, APIRequestFactory
@@ -21,3 +23,11 @@ class AuthAPITestCase(APITestCase):
         request = factory.get(part_url)
         kwargs['request'] = request
         return drt_reverse(viewname, *args, **kwargs)
+
+    def create_admin_user(
+            self, email='test@example.org', password='password'):
+        '''Creates an admin user, and creates a token for that admin user.'''
+        user = User.objects.create_superuser(
+            username=email, email=email, password=password)
+        token = Token.objects.create(user=user)
+        return (user, token)

--- a/authapi/tests/base.py
+++ b/authapi/tests/base.py
@@ -5,6 +5,8 @@ from rest_framework.request import Request
 from rest_framework.reverse import reverse as drt_reverse
 from rest_framework.test import APITestCase, APIRequestFactory
 
+from authapi.models import SeedOrganization, SeedTeam
+
 
 class AuthAPITestCase(APITestCase):
     def get_context(self, url):
@@ -25,9 +27,25 @@ class AuthAPITestCase(APITestCase):
         return drt_reverse(viewname, *args, **kwargs)
 
     def create_admin_user(
-            self, email='test@example.org', password='password'):
+            self, email='admin@example.org', password='password'):
         '''Creates an admin user, and creates a token for that admin user.'''
         user = User.objects.create_superuser(
             username=email, email=email, password=password)
         token = Token.objects.create(user=user)
         return (user, token)
+
+    def create_user(
+            self, email='test@example.org', password='password'):
+        '''Create a user, and create a token for that user.'''
+        user = User.objects.create_user(
+            username=email, email=email, password=password)
+        token = Token.objects.create(user=user)
+        return (user, token)
+
+    def add_permission(self, user, permission_type, object_id=''):
+        '''Creates an organization, create a team for that org, adds the user
+        to that team, and creates the permission on that team.'''
+        org = SeedOrganization.objects.create()
+        team = SeedTeam.objects.create(organization=org)
+        team.users.add(user)
+        team.permissions.create(type=permission_type, object_id=object_id)

--- a/authapi/tests/test_organizations.py
+++ b/authapi/tests/test_organizations.py
@@ -247,8 +247,7 @@ class OrganizationTests(AuthAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_permission_create_organization(self):
-        '''Only admin users, and users with org:admin permissions should be
-        allowed to create organizations.'''
+        '''Only admin users should be allowed to create organizations.'''
         # Unauthenticated request
         data = {
             'title': 'test org',
@@ -267,11 +266,6 @@ class OrganizationTests(AuthAPITestCase):
         self.add_permission(user, 'org:write')
         response = self.client.post(url, data=data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-        # Authenticated request, correct permissions
-        self.add_permission(user, 'org:admin')
-        response = self.client.post(url, data=data)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # Admin user
         _, token = self.create_admin_user()
@@ -329,9 +323,15 @@ class OrganizationTests(AuthAPITestCase):
         response = self.client.put(url, data=data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        # Authenticated request, org:admin permissions
+        # Authenticated request, org:admin permissions, wrong org
         SeedPermission.objects.all().delete()
-        self.add_permission(user, 'org:admin')
+        self.add_permission(user, 'org:admin', org2.pk)
+        response = self.client.put(url, data=data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # Authenticated request, org:admin permissions, correct org
+        SeedPermission.objects.all().delete()
+        self.add_permission(user, 'org:admin', org1.pk)
         response = self.client.put(url, data=data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -370,9 +370,15 @@ class OrganizationTests(AuthAPITestCase):
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-        # Authenticated request, org:admin permissions
+        # Authenticated request, org:admin permissions, wrong org
         SeedPermission.objects.all().delete()
-        self.add_permission(user, 'org:admin')
+        self.add_permission(user, 'org:admin', org2.pk)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # Authenticated request, org:admin permissions, correct org
+        SeedPermission.objects.all().delete()
+        self.add_permission(user, 'org:admin', org1.pk)
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 

--- a/authapi/tests/test_organizations.py
+++ b/authapi/tests/test_organizations.py
@@ -13,6 +13,8 @@ class OrganizationTests(AuthAPITestCase):
     def test_get_organization_list(self):
         '''A GET request to the organizations endpoint should return a list
         of organizations.'''
+        _, token = self.create_admin_user()
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
         org1 = SeedOrganization.objects.create()
         org2 = SeedOrganization.objects.create()
         url = reverse('seedorganization-list')
@@ -32,6 +34,8 @@ class OrganizationTests(AuthAPITestCase):
     def test_get_organization_list_archived(self):
         '''Archived organizations should not appear on the list of
         organizations.'''
+        _, token = self.create_admin_user()
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
         org = SeedOrganization.objects.create(title='test org')
 
         response = self.client.get(reverse('seedorganization-list'))
@@ -45,6 +49,8 @@ class OrganizationTests(AuthAPITestCase):
     def test_get_organization_list_archived_true_queryparam(self):
         '''If the queryparam archived is true, show only archived
         organizations.'''
+        _, token = self.create_admin_user()
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
         org = SeedOrganization.objects.create(title='test org')
 
         response = self.client.get(
@@ -60,6 +66,8 @@ class OrganizationTests(AuthAPITestCase):
     def test_get_organization_list_archived_false_queryparam(self):
         '''If the queryparam archived is false, show only non-archived
         organizations.'''
+        _, token = self.create_admin_user()
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
         org = SeedOrganization.objects.create(title='test org')
 
         response = self.client.get(
@@ -74,6 +82,8 @@ class OrganizationTests(AuthAPITestCase):
 
     def test_get_organization_list_archived_both_queryparam(self):
         '''If the queryparam archived is both, show all organizations.'''
+        _, token = self.create_admin_user()
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
         org1 = SeedOrganization.objects.create(title='test org')
         org1.archived = True
         org1.save()
@@ -89,6 +99,8 @@ class OrganizationTests(AuthAPITestCase):
     def test_get_organization_list_archived_invalid_queryparam(self):
         '''If the archived querystring parameter is not one of true, false, or
         both, an appropriate error should be returned.'''
+        _, token = self.create_admin_user()
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
         response = self.client.get(
             '%s?archived=foo' % reverse('seedorganization-list'))
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -99,6 +111,8 @@ class OrganizationTests(AuthAPITestCase):
     def test_get_organization_list_archived_teams(self):
         '''When getting the list of organizations, the archived teams should
         not be visible.'''
+        _, token = self.create_admin_user()
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
         org = SeedOrganization.objects.create(title='test org')
         team = SeedTeam.objects.create(title='test team', organization=org)
 
@@ -113,6 +127,8 @@ class OrganizationTests(AuthAPITestCase):
     def test_get_organization_list_inactive_users(self):
         '''When getting the list of organizations, the inactive users should
         not be shown in the list of users.'''
+        _, token = self.create_admin_user()
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
         org = SeedOrganization.objects.create(title='test org')
         user = User.objects.create_user('test user')
         org.users.add(user)
@@ -128,6 +144,8 @@ class OrganizationTests(AuthAPITestCase):
     def test_create_organization_no_required(self):
         '''If the POST request is missing required field, an error should be
         returned.'''
+        _, token = self.create_admin_user()
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
         response = self.client.post(reverse('seedorganization-list'))
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data, {
@@ -137,6 +155,8 @@ class OrganizationTests(AuthAPITestCase):
     def test_create_organization(self):
         '''A POST request to the organizations endpoint should create a new
         organization.'''
+        _, token = self.create_admin_user()
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
         data = {
             'title': 'test org',
         }
@@ -151,6 +171,8 @@ class OrganizationTests(AuthAPITestCase):
     def test_get_organization(self):
         '''A GET request to an organization's endpoint should return the
         organization's details.'''
+        _, token = self.create_admin_user()
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
         organization = SeedOrganization.objects.create()
         url = reverse('seedorganization-detail', args=[organization.id])
         context = self.get_context(url)
@@ -163,6 +185,8 @@ class OrganizationTests(AuthAPITestCase):
 
     def test_delete_organization(self):
         '''A DELETE request on an organization should archive it.'''
+        _, token = self.create_admin_user()
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
         org = SeedOrganization.objects.create(title='test org')
         self.assertFalse(org.archived)
 

--- a/authapi/utils.py
+++ b/authapi/utils.py
@@ -1,0 +1,14 @@
+from authapi.models import SeedPermission
+
+
+def get_user_permissions(self, user):
+    '''Returns the queryset of permissions for the given user.'''
+    permissions = SeedPermission.objects.all()
+    # User must be on a team that grants the permission
+    permissions = permissions.filter(seedteam__users=user)
+    # The team must be active
+    permissions = permissions.filter(seedteam__archived=False)
+    # The organization of that team must be active
+    permissions = permissions.filter(
+        seedteam__organization__archived=False)
+    return permissions

--- a/authapi/utils.py
+++ b/authapi/utils.py
@@ -1,7 +1,7 @@
 from authapi.models import SeedPermission
 
 
-def get_user_permissions(self, user):
+def get_user_permissions(user):
     '''Returns the queryset of permissions for the given user.'''
     permissions = SeedPermission.objects.all()
     # User must be on a team that grants the permission
@@ -12,3 +12,11 @@ def get_user_permissions(self, user):
     permissions = permissions.filter(
         seedteam__organization__archived=False)
     return permissions
+
+
+def find_permission(permissions, permission_type, object_id=None):
+    '''Given a queryset of permissions, filters depending on the permission
+    type, and optionally an object id.'''
+    if object_id is not None:
+        return permissions.filter(type=permission_type, object_id=object_id)
+    return permissions.filter(type=permission_type)

--- a/authapi/views.py
+++ b/authapi/views.py
@@ -13,6 +13,7 @@ from rest_framework.viewsets import GenericViewSet
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from authapi.models import SeedOrganization, SeedTeam, SeedPermission
+from authapi import permissions
 from authapi.serializers import (
     OrganizationSerializer, TeamSerializer, UserSerializer, NewUserSerializer,
     ExistingUserSerializer, PermissionSerializer, CreateTokenSerializer,
@@ -35,6 +36,7 @@ def get_true_false_both(query_params, field_name, default):
 class OrganizationViewSet(viewsets.ModelViewSet):
     queryset = SeedOrganization.objects.all()
     serializer_class = OrganizationSerializer
+    permission_classes = (permissions.OrganizationPermission,)
 
     def get_queryset(self):
         '''We want to still be able to modify archived organizations, but they

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         'psycopg2cffi==2.7.4',
         'djangorestframework==3.3.3',
         'drf-extensions==0.2.8',
+        'djangorestframework-composed-permissions==0.1',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
This first PR will probably have a lot of groundwork for permissions handling, so it will just be adding the permissions for the organizations endpoint. Adding the specific permissions to the other endpoints can happen in separate PRs.