### PR TITLE
Use namespace for permissions

### DIFF
--- a/authapi/tests/base.py
+++ b/authapi/tests/base.py
@@ -61,14 +61,15 @@ class AuthAPITestCase(APITestCase):
         token = Token.objects.create(user=user)
         return (user, token)
 
-    def add_permission(self, user, permission_type, object_id=''):
+    def add_permission(
+            self, user, permission_type, object_id='', namespace='__auth__'):
         '''Creates an organization, create a team for that org, adds the user
         to that team, and creates the permission on that team.'''
         org = SeedOrganization.objects.create()
         team = SeedTeam.objects.create(organization=org)
         team.users.add(user)
         permission = team.permissions.create(
-            type=permission_type, object_id=object_id)
+            type=permission_type, object_id=object_id, namespace=namespace)
         return team, permission
 
     def patch_client_data_json(self):

--- a/authapi/tests/test_organizations.py
+++ b/authapi/tests/test_organizations.py
@@ -662,7 +662,7 @@ class OrganizationTeamTests(AuthAPITestCase):
         data = {
             'type': 'foo:bar',
             'object_id': '2',
-            'namespace': 'foo',
+            'namespace': '__auth__',
         }
 
         self.assertEqual(len(team.permissions.all()), 0)
@@ -689,7 +689,7 @@ class OrganizationTeamTests(AuthAPITestCase):
             data={
                 'type': 'organization:admin',
                 'object_id': org.pk,
-                'namespace': 'foo'
+                'namespace': '__auth__'
             })
         self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
 
@@ -849,7 +849,7 @@ class OrganizationTeamTests(AuthAPITestCase):
             data={
                 'type': 'org:admin',
                 'object_id': org2.pk,
-                'namespace': 'foo'
+                'namespace': '__auth__'
             })
         self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -862,7 +862,7 @@ class OrganizationTeamTests(AuthAPITestCase):
             data={
                 'type': 'org:admin',
                 'object_id': org1.pk,
-                'namespace': 'foo'
+                'namespace': '__auth__'
             })
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
 
@@ -875,7 +875,7 @@ class OrganizationTeamTests(AuthAPITestCase):
             data={
                 'type': 'team:admin',
                 'object_id': team1.pk,
-                'namespace': 'foo'
+                'namespace': '__auth__'
             })
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
 
@@ -911,7 +911,7 @@ class OrganizationTeamTests(AuthAPITestCase):
             data={
                 'type': 'team:admin',
                 'object_id': team.pk,
-                'namespace': 'foo'
+                'namespace': '__auth__'
             })
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
 
@@ -924,7 +924,7 @@ class OrganizationTeamTests(AuthAPITestCase):
             data={
                 'type': 'team:admin',
                 'object_id': team2.pk,
-                'namespace': 'foo'
+                'namespace': '__auth__'
             })
         self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -937,7 +937,7 @@ class OrganizationTeamTests(AuthAPITestCase):
             data={
                 'type': 'org:admin',
                 'object_id': org.pk,
-                'namespace': 'foo'
+                'namespace': '__auth__'
             })
         self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -950,7 +950,7 @@ class OrganizationTeamTests(AuthAPITestCase):
             data={
                 'type': 'foo:bar',
                 'object_id': '7',
-                'namespace': 'foo'
+                'namespace': '__auth__'
             })
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
 

--- a/authapi/tests/test_teams.py
+++ b/authapi/tests/test_teams.py
@@ -641,7 +641,7 @@ class TeamTests(AuthAPITestCase):
             reverse('seedteam-permissions-list', args=[team.id]), data={
                 'type': 'team:admin',
                 'object_id': team.pk,
-                'namespace': 'foo',
+                'namespace': '__auth__',
             })
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -650,7 +650,7 @@ class TeamTests(AuthAPITestCase):
             reverse('seedteam-permissions-list', args=[team.id]), data={
                 'type': 'team:admin',
                 'object_id': team2.pk,
-                'namespace': 'foo',
+                'namespace': '__auth__',
             })
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -659,7 +659,7 @@ class TeamTests(AuthAPITestCase):
             reverse('seedteam-permissions-list', args=[team.id]), data={
                 'type': 'org:admin',
                 'object_id': org.pk,
-                'namespace': 'foo',
+                'namespace': '__auth__',
             })
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -668,7 +668,7 @@ class TeamTests(AuthAPITestCase):
             reverse('seedteam-permissions-list', args=[team.id]), data={
                 'type': 'foo:bar',
                 'object_id': '7',
-                'namespace': 'foo',
+                'namespace': '__auth__',
             })
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -688,7 +688,7 @@ class TeamTests(AuthAPITestCase):
             reverse('seedteam-permissions-list', args=[team.id]), data={
                 'type': 'team:admin',
                 'object_id': team2.pk,
-                'namespace': 'foo',
+                'namespace': '__auth__',
             })
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -697,7 +697,7 @@ class TeamTests(AuthAPITestCase):
             reverse('seedteam-permissions-list', args=[team.id]), data={
                 'type': 'org:admin',
                 'object_id': org.pk,
-                'namespace': 'foo',
+                'namespace': '__auth__',
             })
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -706,7 +706,7 @@ class TeamTests(AuthAPITestCase):
             reverse('seedteam-permissions-list', args=[team.id]), data={
                 'type': 'org:admin',
                 'object_id': org2.pk,
-                'namespace': 'foo',
+                'namespace': '__auth__',
             })
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -806,7 +806,7 @@ class TeamTests(AuthAPITestCase):
 
         # org:admin
         permission = SeedPermission.objects.create(
-            type='org:admin', object_id=org.pk, namespace='foo')
+            type='org:admin', object_id=org.pk, namespace='__auth__')
         team.permissions.add(permission)
         response = self.client.delete(
             reverse('seedteam-permissions-detail',
@@ -817,7 +817,7 @@ class TeamTests(AuthAPITestCase):
         wrong_team = SeedTeam.objects.create(
             title='test team 2', organization=org)
         permission = wrong_team.permissions.create(
-            type='team:admin', object_id=wrong_team.pk, namespace='foo')
+            type='team:admin', object_id=wrong_team.pk, namespace='__auth__')
         response = self.client.delete(
             reverse('seedteam-permissions-detail',
                     args=[wrong_team.id, permission.id]))
@@ -845,7 +845,7 @@ class TeamTests(AuthAPITestCase):
 
         # incorrect team object_id
         permission = SeedPermission.objects.create(
-            type='team:admin', object_id=team2.pk, namespace='foo')
+            type='team:admin', object_id=team2.pk, namespace='__auth__')
         team2.permissions.add(permission)
         response = self.client.delete(
             reverse('seedteam-permissions-detail',
@@ -854,7 +854,7 @@ class TeamTests(AuthAPITestCase):
 
         # org:admin
         permission = SeedPermission.objects.create(
-            type='org:admin', object_id=org.pk, namespace='foo')
+            type='org:admin', object_id=org.pk, namespace='__auth__')
         team.permissions.add(permission)
         response = self.client.delete(
             reverse('seedteam-permissions-detail',
@@ -863,7 +863,7 @@ class TeamTests(AuthAPITestCase):
 
         # org:admin incorrect org
         permission = SeedPermission.objects.create(
-            type='org:admin', object_id=org2.pk, namespace='foo')
+            type='org:admin', object_id=org2.pk, namespace='__auth__')
         team2.permissions.add(permission)
         response = self.client.delete(
             reverse('seedteam-permissions-detail',

--- a/authapi/utils.py
+++ b/authapi/utils.py
@@ -14,9 +14,11 @@ def get_user_permissions(user):
     return permissions
 
 
-def find_permission(permissions, permission_type, object_id=None):
+def find_permission(
+        permissions, permission_type, object_id=None, namespace=None):
     '''Given a queryset of permissions, filters depending on the permission
-    type, and optionally an object id.'''
+    type, and optionally an object id and namespace.'''
     if object_id is not None:
-        return permissions.filter(type=permission_type, object_id=object_id)
+        return permissions.filter(
+            type=permission_type, object_id=object_id, namespace=namespace)
     return permissions.filter(type=permission_type)

--- a/seed_auth_api/settings.py
+++ b/seed_auth_api/settings.py
@@ -111,3 +111,6 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.AllowAny',
     ),
 }
+
+# Set the namespace to use for internal permissions.
+PERMISSION_NAMESPACE = '__auth__'


### PR DESCRIPTION
Have the API use a namespace for its own permissions, and have it configurable through the settings file.