### PR TITLE
Fix duplicates in /teams/ results

### DIFF
--- a/authapi/tests/test_teams.py
+++ b/authapi/tests/test_teams.py
@@ -119,6 +119,22 @@ class TeamTests(AuthAPITestCase):
             response.data[0]['permissions'][0]['type'],
             perm.type)
 
+    def test_get_team_list_filter_permission_type_multiple(self):
+        '''If a team has multiple permissions that match, the team should only
+        be listed once.'''
+        _, token = self.create_admin_user()
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+        org = SeedOrganization.objects.create()
+        team = SeedTeam.objects.create(organization=org)
+        team.permissions.create(
+            type='bar:foo:bar', object_id='2', namespace='bar')
+        team.permissions.create(
+            type='bar:foo:bar', object_id='3', namespace='bar')
+
+        response = self.client.get(
+            '%s?permission_contains=foo' % reverse('seedteam-list'))
+        self.assertEqual(len(response.data), 1)
+
     def test_get_team_list_filter_object_id(self):
         '''If the querystring argument object_id is present, we should only
         display teams that have that object id in one of their permissions.'''
@@ -138,6 +154,22 @@ class TeamTests(AuthAPITestCase):
         self.assertEqual(
             response.data[0]['permissions'][0]['object_id'],
             perm.object_id)
+
+    def test_get_team_list_filter_object_id_multiple(self):
+        '''If a team has multiple permissions that match, the team should only
+        be listed once.'''
+        _, token = self.create_admin_user()
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+        org = SeedOrganization.objects.create()
+        team = SeedTeam.objects.create(organization=org)
+        team.permissions.create(
+            type='bar:foo:bar', object_id='2', namespace='bar')
+        team.permissions.create(
+            type='bar:bar:bar', object_id='2', namespace='bar')
+
+        response = self.client.get(
+            '%s?object_id=2' % reverse('seedteam-list'))
+        self.assertEqual(len(response.data), 1)
 
     def test_get_team_list_archived_users(self):
         '''When getting the list of teams, inactive users should not appear

--- a/authapi/views.py
+++ b/authapi/views.py
@@ -118,11 +118,12 @@ class BaseTeamViewSet(
                 'permission_contains', None)
             if permission is not None:
                 queryset = queryset.filter(
-                    permissions__type__contains=permission)
+                    permissions__type__contains=permission).distinct()
 
             object_id = self.request.query_params.get('object_id', None)
             if object_id is not None:
-                queryset = queryset.filter(permissions__object_id=object_id)
+                queryset = queryset.filter(
+                    permissions__object_id=object_id).distinct()
 
             permission = permissions.TeamPermission()
             queryset = [


### PR DESCRIPTION
When the `permission_contains` query parameter is used, multiple permission matches for the same team results in the team appearing in the list multiple times.