### PR TITLE
Support filtering by namespace for /teams/

### DIFF
--- a/authapi/views.py
+++ b/authapi/views.py
@@ -125,6 +125,11 @@ class BaseTeamViewSet(
                 queryset = queryset.filter(
                     permissions__object_id=object_id).distinct()
 
+            namespace = self.request.query_params.get('namespace', None)
+            if namespace is not None:
+                queryset = queryset.filter(
+                    permissions__namespace=namespace).distinct()
+
             permission = permissions.TeamPermission()
             queryset = [
                 team for team in queryset if

--- a/docs/http_api.rst
+++ b/docs/http_api.rst
@@ -589,16 +589,19 @@ Teams
 
     :query string type_contains:
         The type field on one of the resulting team's permissions must contain
-        this string.
+        this string. (optional)
     :query string object_id:
         All the object_id fields on one of the resulting team's permissions
-        must equal this string.
+        must equal this string. (optional)
+    :quert string namespace:
+        All the namespace fields on one of the resulting team's permissions
+        must equal this string. (optional)
 
     **Example request**:
 
     .. sourcecode:: http
 
-        GET /teams/?permission_contains=org&object_id=3 HTTP/1.1
+        GET /teams/?permission_contains=org&object_id=3&namespace=seed_auth HTTP/1.1
 
     **Example response**:
 


### PR DESCRIPTION
We need to be able to filter by namespace when retrieving a list of all teams a user has access to.