### PR TITLE
More consistent api endpoints for adding users to teams and orgs

### DIFF
--- a/authapi/serializers.py
+++ b/authapi/serializers.py
@@ -44,12 +44,6 @@ class PermissionSerializer(serializers.ModelSerializer):
         fields = ('id', 'type', 'object_id', 'namespace')
 
 
-class ExistingUserSerializer(serializers.Serializer):
-    '''Serializer for adding/removing an existing user.'''
-    user_id = serializers.PrimaryKeyRelatedField(
-        queryset=User.objects.all())
-
-
 class OrganizationSerializer(serializers.ModelSerializer):
     teams = TeamSummarySerializer(
         many=True, source='get_active_teams', read_only=True)

--- a/authapi/tests/test_organizations.py
+++ b/authapi/tests/test_organizations.py
@@ -413,9 +413,10 @@ class OrganizationUserTests(AuthAPITestCase):
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
         org = SeedOrganization.objects.create(title='test org')
 
-        response = self.client.put(
-            reverse('seedorganization-users-detail',
+        response = self.client.put(reverse(
+            'seedorganization-users-detail',
             args=[org.id, 'missing-user']))
+
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_remove_user_from_organization(self):

--- a/authapi/views.py
+++ b/authapi/views.py
@@ -211,7 +211,6 @@ class TeamPermissionViewSet(
 class TeamUsersViewSet(NestedViewSetMixin, GenericViewSet):
     '''Nested viewset that allows users to add or remove users from teams.'''
     queryset = User.objects.all()
-    serializer_class = ExistingUserSerializer
     permission_classes = (IsAuthenticated,)
 
     def check_team_permissions(self, request, teamid, orgid=None):
@@ -229,13 +228,11 @@ class TeamUsersViewSet(NestedViewSetMixin, GenericViewSet):
             )
         return team
 
-    def create(
-            self, request, parent_lookup_seedteam=None,
+    def update(
+            self, request, pk=None, parent_lookup_seedteam=None,
             parent_lookup_seedteam__organization=None):
         '''Add a user to a team.'''
-        serializer = self.get_serializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        user = get_object_or_404(User, pk=serializer.data['user_id'])
+        user = get_object_or_404(User, pk=pk)
         team = self.check_team_permissions(
             request, parent_lookup_seedteam,
             parent_lookup_seedteam__organization)

--- a/authapi/views.py
+++ b/authapi/views.py
@@ -17,8 +17,7 @@ from authapi.models import SeedOrganization, SeedTeam, SeedPermission
 from authapi import permissions
 from authapi.serializers import (
     OrganizationSerializer, TeamSerializer, UserSerializer, NewUserSerializer,
-    ExistingUserSerializer, PermissionSerializer, CreateTokenSerializer,
-    PermissionsUserSerializer)
+    PermissionSerializer, CreateTokenSerializer, PermissionsUserSerializer)
 
 
 def get_true_false_both(query_params, field_name, default):
@@ -67,11 +66,9 @@ class OrganizationUsersViewSet(NestedViewSetMixin, viewsets.ViewSet):
     organizations.'''
     permission_classes = (permissions.OrganizationUsersPermission,)
 
-    def create(self, request, parent_lookup_organization=None):
+    def update(self, request, pk=None, parent_lookup_organization=None):
         '''Add a user to an organization.'''
-        serializer = ExistingUserSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        user = serializer.validated_data.get('user_id')
+        user = get_object_or_404(User, pk=pk)
         org = get_object_or_404(
             SeedOrganization, pk=parent_lookup_organization)
         self.check_object_permissions(request, org)

--- a/docs/http_api.rst
+++ b/docs/http_api.rst
@@ -581,7 +581,7 @@ to belong to exactly one organization, but an organization can have many teams.
 
     See `Remove permission from team`_. Limited to teams that belong to the organization.
 
-.. http:post:: /organizations/(int:organization_id)/teams/(int:team:id)/users/(int:user_id)/
+.. http:put:: /organizations/(int:organization_id)/teams/(int:team:id)/users/(int:user_id)/
 
     See `Add user to team`_. Limited to teams that belong to the organization.
 

--- a/docs/http_api.rst
+++ b/docs/http_api.rst
@@ -462,14 +462,12 @@ to belong to exactly one organization, but an organization can have many teams.
 
       HTTP/1.1 204 No Content
 
-.. http:post:: /organizations/(int:organization_id)/users/
+.. http:put:: /organizations/(int:organization_id)/users/(int:user_id)/
 
     Add a user to an existing organization.
 
     Requires admin user, or any user that has 'org:admin' permissions for that
     organization.
-
-    :<json int user_id: The ID of the user to add.
 
     :status 204: User was successfully added.
 
@@ -477,10 +475,8 @@ to belong to exactly one organization, but an organization can have many teams.
 
     .. sourcecode:: http
 
-        POST /organizations/4/users/ HTTP/1.1
+        PUT /organizations/4/users/2/ HTTP/1.1
         Content-Type: application/json
-
-        {"user_id": 2}
 
     **Example response**:
 
@@ -585,7 +581,7 @@ to belong to exactly one organization, but an organization can have many teams.
 
     See `Remove permission from team`_. Limited to teams that belong to the organization.
 
-.. http:post:: /organizations/(int:organization_id)/teams/(int:team:id)/users/
+.. http:post:: /organizations/(int:organization_id)/teams/(int:team:id)/users/(int:user_id)/
 
     See `Add user to team`_. Limited to teams that belong to the organization.
 
@@ -928,11 +924,9 @@ Teams
         HTTP/1.1 204 No Content
 
 .. _Add user to team:
-.. http:post:: /teams/(int:team_id)/users/
+.. http:put:: /teams/(int:team_id)/users/(int:user_id)/
 
     Add an existing user to an existing team.
-
-    :<json int user_id: The ID of the user to add to the team.
 
     :status 204: successfully added the user to the team.
 
@@ -940,12 +934,8 @@ Teams
 
     .. sourcecode:: http
 
-        POST /teams/2/users/ HTTP/1.1
+        PUT /teams/2/users/1/ HTTP/1.1
         Content-Type: application/json
-
-        {
-            "user_id": 1
-        }
 
     **Example response**:
 


### PR DESCRIPTION
At the moment we do:

```http
POST /teams/23/users/
{"user_id": 21}
```

It would be more consistent with the rest of the api to be able to do:

```http
PUT /teams/23/users/21
```
