### PR TITLE
Add introduction to docs

### DIFF
--- a/docs/http_api.rst
+++ b/docs/http_api.rst
@@ -4,35 +4,6 @@
 Seed Auth HTTP API
 ==================
 
-Overview
-^^^^^^^^
-Seed Auth was designed to allow one or more applications to be able to delegate authentication and user and permission management to a single, internal service. For the case of multiple applications, this avoids the need for users to authenticate separately for each application.
-
-An application would use Seed Auth as follows:
-
-   1. Permissions are added to teams of users in Seed Auth, where each permission could be an application-specific permission, or a :ref:`permission relevant to Seed Auth <permissions>`.
-   2. An authentication token is acquired for a user in Seed Auth.
-   3. When a client sends a request to an application, the application makes a request to Seed Auth using the authentication token given in the client's request's ``Authorization`` header, and is given back the permissions granted to the authenticated user. The user's permissions are used by the application to determine whether the user has access to the requested resource.
-
-
-::
-
-   client ------------------> application ----------------> seed-auth-api
-
-           GET /things/23                  Get /user
-           Authorization: Token 1234       Authorization: Token 1234
-
-          <------------------             <---------------
-
-             {id: '23'}                   {
-                                            ...
-                                            permissions: [{
-                                              namespace: 'app:foo',
-                                              type: 'thing:read',
-                                              object_id: '23'
-                                            }]
-                                          }
-
 .. _authentication:
 
 Authentication

--- a/docs/http_api.rst
+++ b/docs/http_api.rst
@@ -6,7 +6,7 @@ Seed Auth HTTP API
 
 Overview
 ^^^^^^^^
-Seed Auth was designed to allow one or more applications to be able to delegate authentication, user and permission management to a single, internal service. For the case of multiple applications, this avoids the need for users to authenticate separately for each application.
+Seed Auth was designed to allow one or more applications to be able to delegate authentication and user and permission management to a single, internal service. For the case of multiple applications, this avoids the need for users to authenticate separately for each application.
 
 An application would use Seed Auth as follows:
 

--- a/docs/http_api.rst
+++ b/docs/http_api.rst
@@ -1,11 +1,37 @@
 .. _http-api:
 
 
-HTTP API
-========
+Seed Auth HTTP API
+==================
 
-Seed Auth's HTTP API.
+Overview
+^^^^^^^^
+Seed Auth was designed to allow one or more applications to be able to delegate authentication, user and permission management to a single, internal service. For the case of multiple applications, this avoids the need for users to authenticate separately for each application.
 
+An application would use Seed Auth as follows:
+
+   1. Permissions are added to teams of users in Seed Auth, where each permission could be an application-specific permission, or a :ref:`permission relevant to Seed Auth <permissions>`.
+   2. An authentication token is acquired for a user in Seed Auth.
+   3. When a client sends a request to an application, the application makes a request to Seed Auth using the authentication token given in the client's request's ``Authorization`` header, and is given back the permissions granted to the authenticated user. The user's permissions are used by the application to determine whether the user has access to the requested resource.
+
+
+::
+
+   client ------------------> application ----------------> seed-auth-api
+
+           GET /things/23                  Get /user
+           Authorization: Token 1234       Authorization: Token 1234
+
+          <------------------             <---------------
+
+             {id: '23'}                   {
+                                            ...
+                                            permissions: [{
+                                              namespace: 'app:foo',
+                                              type: 'thing:read',
+                                              object_id: '23'
+                                            }]
+                                          }
 
 .. _authentication:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,35 @@ Contents:
    http_api
 
 
+Overview
+^^^^^^^^
+Seed Auth was designed to allow one or more applications to be able to delegate authentication and user and permission management to a single, internal service. For the case of multiple applications, this avoids the need for users to authenticate separately for each application.
+
+An application would use Seed Auth as follows:
+
+   1. Permissions are added to teams of users in Seed Auth, where each permission could be an application-specific permission, or a :ref:`permission relevant to Seed Auth <permissions>`.
+   2. An authentication token is acquired for a user in Seed Auth.
+   3. When a client sends a request to an application, the application makes a request to Seed Auth using the authentication token given in the client's request's ``Authorization`` header, and is given back the permissions granted to the authenticated user. The user's permissions are used by the application to determine whether the user has access to the requested resource.
+
+
+::
+
+   client ------------------> application ----------------> seed-auth-api
+
+           GET /things/23                  Get /user
+           Authorization: Token 1234       Authorization: Token 1234
+
+          <------------------             <---------------
+
+             {id: '23'}                   {
+                                            ...
+                                            permissions: [{
+                                              namespace: 'app:foo',
+                                              type: 'thing:read',
+                                              object_id: '23'
+                                            }]
+                                          }
+
 
 Indices and tables
 ==================


### PR DESCRIPTION
We need to add info to the docs about what problem seed-auth-api is solving, how it solves it, and how one could use it for their service.