### PR TITLE
Use psycopg2 instead of psycopg2cffi

### DIFF
--- a/seed_auth_api/settings.py
+++ b/seed_auth_api/settings.py
@@ -13,9 +13,6 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 import os
 import dj_database_url
 
-from psycopg2cffi import compat
-compat.register()
-
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     install_requires=[
         'Django==1.10.5',
         'dj-database-url==0.4.2',
-        'psycopg2cffi==2.7.5',
+        'psycopg2==2.7.3.1',
         'djangorestframework==3.5.3',
         'drf-extensions==0.3.1',
         'djangorestframework-composed-permissions==0.1',


### PR DESCRIPTION
This means PyPy is no longer supported...but afaics it was never used. PyPy support can be added back if necessary by installing & using psycopg2cffi optionally.